### PR TITLE
Update parse_git_dirty syntax

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -8,8 +8,8 @@
   
   # This function checks if your branch has uncommited changes on them.
   function parse_git_dirty {
-    [[ $(git status 2> /dev/null | tail -n1) == "nothing to commit, working directory clean" ]] && echo " ✔"
-    [[ $(git status 2> /dev/null | tail -n1) != "nothing to commit, working directory clean" ]] && echo " ✘"
+    [[ $(git status 2> /dev/null | tail -n1) == "nothing to commit, working tree clean" ]] && echo " ✔"
+    [[ $(git status 2> /dev/null | tail -n1) != "nothing to commit, working tree clean" ]] && echo " ✘"
   }
 
   # This function is called in your prompt to output your active git branch.


### PR DESCRIPTION
Hello,

Former Flatiron School student here! I was class Web-0615 (summer 2015).

I noticed a [change in git](https://github.com/git/git/commit/2a0e6cdedab306eccbd297c051035c13d0266343) where the text displayed when running `git status` changed. This ended up breaking `parse_git_dirty` because the strings would never match. 

I noticed this happening even on my freshly cloned repos and knew something was up!

This PR changes the string that is used in the`parse_git_dirty` function so that it adheres to this new syntax.

I'm not sure if y'all still use this repo but thought I'd help out! Cheers.